### PR TITLE
fix: 토큰저장방식변경 -#15

### DIFF
--- a/src/containers/login/LoginEmailContainer.tsx
+++ b/src/containers/login/LoginEmailContainer.tsx
@@ -28,7 +28,7 @@ const LoginEmailContainer = () => {
   const loginMutation = useMutation({
     mutationFn: login,
     onSuccess: (response) => {
-      const token = response.headers['authorization'];
+      const token = response.headers['authorization'].split(' ')[1];
       localStorage.setItem('authorization', token);
       navigate('/');
     },


### PR DESCRIPTION
로그인 토큰저장방식의 유형을제외한 토큰값만 저장합니다. 