### PR TITLE
fix: provider problem by google analytics -#95

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import React, { useEffect } from 'react';
-import { RouterProvider, useLocation } from 'react-router-dom';
+import { RouterProvider } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -19,11 +19,22 @@ const queryClient = new QueryClient({
 });
 
 function App() {
-  const location = useLocation();
-
   useEffect(() => {
-    ga.pageview(location.pathname + location.search); // 페이지 변경 시 GA pageview 호출
-  }, [location]);
+    const sendPageview = () => {
+      ga.pageview(window.location.pathname + window.location.search);
+    };
+
+    sendPageview(); // 초기 페이지 로드 시 한 번 실행
+
+    const unsubscribe = router.subscribe((state) => {
+      // 경로 변경마다 페이지뷰 전송
+      if (state.location) {
+        sendPageview();
+      }
+    });
+
+    return () => unsubscribe();
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
### Description 
> 구글 애널리틱스 적용을위해 최적화하는도중 provider에 오류가 떠서 로그인이 안되는문제가 있어 해결했습니다. 

### Problem
> 구글 애널리틱스를 적용하기위해 리액트 최적화작업을 했는데, 로그인 된 상태에서는 문제가없다가 로그아웃하고 접속하면 에러가 뜨는 경우가 발생했습니다 

### Solution
> react-router-dom에서 지원하는 RouterProvider에 router로 경로를 설정해놨었는데, RouterProvider는 useLocation을 지원하지 않았습니다. 따라서 location을 없애고 윈도우에 내장된 location을 이용하여 수정했습니다. 